### PR TITLE
Feature top param

### DIFF
--- a/mainV2.js
+++ b/mainV2.js
@@ -154,7 +154,7 @@ async function mainV2(token) {
     let [spnFedCred,appFedCred] = filteredOpsNext
 
     let appFedCredsListBatch = appFedCred?.objects
-    .map(s => s = { url: `/applications/${s?.id}/federatedIdentityCredentials`, method: "GET", providedId: s?.id })
+    .map(s => s = { url: `/applications/${s?.id}/federatedIdentityCredentials?$top=999`, method: "GET", providedId: s?.id })
 
     // modify so, that the ID created in MAP can be mapped back to result
     let appFedCreds = await graphBatching(appFedCredsListBatch, token?.access_token, (item) => item?.map(s => s = { content: s?.body?.value, id: s?.id }), undefined, 5, 200)
@@ -162,7 +162,7 @@ async function mainV2(token) {
     console.log(appFedCreds?.length)
 
     let spnFedCredsListBatch = spnFedCred?.objects
-    .map(s => s = { url: `/servicePrincipals/${s?.id}/federatedIdentityCredentials`, method: "GET", providedId: s?.id })
+    .map(s => s = { url: `/servicePrincipals/${s?.id}/federatedIdentityCredentials?$top=999`, method: "GET", providedId: s?.id })
 
     // modify so, that the ID created in MAP can be mapped back to result
     let spnFedCreds = await graphBatching(spnFedCredsListBatch, token?.access_token, (item) => item?.map(s => s = { content: s?.body?.value, id: s?.id }), undefined, 5, 200)
@@ -176,7 +176,7 @@ async function mainV2(token) {
     // AppOwnersOwners and
 
     let AppOwnersOwnersBatch = applications.filter(app => app.HasOwner == 'appsOwner')
-    .map(s => s = { url: `/applications/${s?.id}/owners?$select=id,displayName`, method: "GET", providedId: s?.appId })
+    .map(s => s = { url: `/applications/${s?.id}/owners?$select=id,displayName&$top=999`, method: "GET", providedId: s?.appId })
 
     // modify so, that the ID created in MAP can be mapped back to result
     let appOwners = await graphBatching(AppOwnersOwnersBatch, token?.access_token, (item) => item?.map(s => s = { content: s?.body?.value, id: s?.id }), undefined, 5, 200)
@@ -185,7 +185,7 @@ async function mainV2(token) {
 
 
     let SPNOwnersOwnersBatch = servicePrincipals.filter(spn => spn.HasOwner == 'spnOwner')
-    .map(s => s = { url: `/servicePrincipals/${s?.id}/owners?$select=id,displayName,AppId`, method: "GET", providedId: s?.appId })
+    .map(s => s = { url: `/servicePrincipals/${s?.id}/owners?$select=id,displayName,AppId&$top=999`, method: "GET", providedId: s?.appId })
 
     // modify so, that the ID created in MAP can be mapped back to result
     let SPNOwners = await graphBatching(SPNOwnersOwnersBatch, token?.access_token, (item) => item?.map(s => s = { content: s?.body?.value, id: s?.id }), undefined, 5, 200)

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,14 @@
+- [Azure AD Application Analytics Solution](#azure-ad-application-analytics-solution)
+- [Before using this tool](#before-using-this-tool)
+- [Release notes](#release-notes)
+  - [List of checks](#list-of-checks)
+- [Requirements and operation](#requirements-and-operation)
+  - [Use existing storage account](#use-existing-storage-account)
+  - [Provision new](#provision-new)
+  - [Operation](#operation)
+  - [After running the tool](#after-running-the-tool)
+- [Limitations](#limitations)
+- [Contribution](#contribution)
 
 
 # Azure AD Application Analytics Solution
@@ -144,6 +155,12 @@ node main
 
 - Remove installation of this service (removes the json files that were stored for the query)
 - Delete the resource group (if you provisoned new one) ``az group delete -n $rg`` 
+
+
+# Limitations
+
+This tool supports paginated results for the initial batch creation. The later operations which are done by Native MS Graph JSON batching at this point do not look for paginated results. This means, that if there is an app, that has more than 999 appRoleAssignments, it will only display the first 999 assignments that are granted for that app (technical limit of these assignments is 1500, so it is possible that some app has been given more than 999 assignments)
+- Same applies for app that has more than 999 client secrets, or more than 999 owners, the owners over that amount are not shown on the report 
 
 
 # Contribution

--- a/readme.md
+++ b/readme.md
@@ -159,9 +159,8 @@ node main
 
 # Limitations
 
-This tool supports paginated results for the initial batch creation. The later operations which are done by Native MS Graph JSON batching at this point do not look for paginated results. This means, that if there is an app, that has more than 999 appRoleAssignments, it will only display the first 999 assignments that are granted for that app (technical limit of these assignments is 1500, so it is possible that some app has been given more than 999 assignments)
+This tool supports paginated results for the initial batch creation. The later operations which are done by Native MS Graph JSON batching at this point do not look for paginated results. This means that if there is an app, that has more than 999 appRoleAssignments, it will only display the first 999 assignments that are granted for that app (technical limit of these assignments is 1500, so it is possible that some app has been given more than 999 assignments)
 - Same applies for app that has more than 999 client secrets, or more than 999 owners, the owners over that amount are not shown on the report 
-
 
 # Contribution
 Feel free to open issue or pull requests


### PR DESCRIPTION
Document limitation of returning individual app role assignments that are given to single principal is set to 999, to avoid doing paging beyond the initial paging that is done on the beginning at the use of the tool

_"A user, group, or service principal can have a maximum of 1,500 app role assignments. The limitation is on the service principal, user, or group across all app roles and not on the number of assignments on a single app role."_

https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-active-directory-limits